### PR TITLE
fixed issue with create() when scheme not provided. unclear what the pro...

### DIFF
--- a/burst/http.py
+++ b/burst/http.py
@@ -61,6 +61,8 @@ class Request():
       self.url = url
     else:
       p_url = urlparse.urlparse(url)
+      if not p_url.scheme:
+        raise BurstException("No scheme provided (http:// or https://): " + str(url)) #could probably just default to http://
       self.url = urlparse.urlunparse(("", "") + p_url[2:])
       self.hostname = p_url.hostname
       if not self.hostname:


### PR DESCRIPTION
[hax@metaverse burst]$ burst
  _                _  
 | |__ _  _ _ _ **| |_ 
 | '_ \ || | '_(_-<  _|
 |_.**/_,_|_| /**/\**|

> > > c('www.google.com')
> > > Traceback (most recent call last):
> > >   File "<console>", line 1, in <module>
> > >   File "/usr/lib/python2.7/site-packages/burst/http.py", line 376, in create
> > >     """.format(url, host))
> > >   File "/usr/lib/python2.7/site-packages/burst/http.py", line 67, in **init**
> > >     raise BurstException("No hostname: " + str(url))
> > > BurstException: No hostname: www.google.com

Unclear that missing scheme is the problem. Modified so 

> > > c('www.google.com')
> > > Traceback (most recent call last):
> > >   File "<console>", line 1, in <module>
> > >   File "/usr/lib/python2.7/site-packages/burst/http.py", line 378, in create
> > >     """.format(url, host))
> > >   File "/usr/lib/python2.7/site-packages/burst/http.py", line 65, in **init**
> > >     raise BurstException("No scheme provided (http:// or https://): " + str(url)) #could probably just default to http://
> > > BurstException: No scheme provided (http:// or https://): www.google.com
