### PR TITLE
command: add grep command

### DIFF
--- a/burst/all.py
+++ b/burst/all.py
@@ -10,7 +10,7 @@ from burst.session   import switch_session, ss, save, list_sessions, \
                              lss, archive
 from burst.utils     import encode, e, ee, decode, d, dd, parse_qs, \
                              urlencode, view, idle, external_view, pxml, \
-                             pjson, d64, e64
+                             pjson, d64, e64, grep
 from burst.spider    import spider, s
 from burst.alert     import NullAlerter, GenericAlerter, RequestKeywordAlerter
 from burst.external  import import_from_burp

--- a/burst/color.py
+++ b/burst/color.py
@@ -7,6 +7,7 @@ style_error = "\033[31m"
 style_warning = "\033[33m"
 style_info = "\033[34m"
 style_stealthy = "\033[37m"
+style_bright_red = "\033[1;31m"
 
 def __generic_style(c):
   def _x(s, rl=False):
@@ -25,6 +26,7 @@ warning = __generic_style(style_warning)
 great_success = __generic_style(style_great_success)
 stealthy = __generic_style(style_stealthy)
 info = __generic_style(style_info)
+bright_red = __generic_style(style_bright_red)
 
 def color_status(status, rl=False):
   if status.startswith("2"):

--- a/burst/console.py
+++ b/burst/console.py
@@ -96,13 +96,17 @@ class ColorPrompt(object):
 re_print_alias = re.compile(r'^p\s(.*)')
 re_view_alias = re.compile(r'^v\s(.*)')
 re_extview_alias = re.compile(r'^w\s(.*)')
+re_grep_alias = re.compile(r'^g(?:rep)?((?: -o)?) +(.+?) +(.+)')
+def __re_grep_alias_callback(m):
+  only = (m.group(1) == ' -o')
+  pattern = m.group(2).replace('\x5c','\x5c\x5c').replace(r'"','\x5c"')
+  return r'grep("{}", ({}), only={})'.format(pattern, m.group(3), only)
+
 def expand_alias(line):
-  if re_print_alias.match(line):
-    line = re_print_alias.sub(r'print \1', line)
-  if re_view_alias.match(line):
-    line = re_view_alias.sub(r'view(\1)', line)
-  if re_extview_alias.match(line):
-    line = re_extview_alias.sub(r'external_view(\1)', line)
+  line = re_print_alias.sub(r'print \1', line)
+  line = re_view_alias.sub(r'view(\1)', line)
+  line = re_extview_alias.sub(r'external_view(\1)', line)
+  line = re_grep_alias.sub(__re_grep_alias_callback, line)
   return line
 
 class BurstInteractiveConsole(code.InteractiveConsole):

--- a/burst/utils.py
+++ b/burst/utils.py
@@ -13,6 +13,7 @@ import subprocess
 import collections
 
 from burst.conf import conf
+from burst.color import bright_red as color_bright_red
 
 try:
   import termios
@@ -43,7 +44,7 @@ def pxml(r):
       x = etree.fromstring(s)
       return etree.tostring(x, pretty_print = True)
     except ValueError:
-      print "Shit Tyrone, get it together!"
+      print "Shit Tyrone, get it together!" # TODO what a professional error message
     except etree.XMLSyntaxError:
       print "Unable to parse the XML. Looking for goat sex?"
   else:
@@ -124,6 +125,22 @@ def external_view(args):
     f.write(str(args))
   subprocess.Popen(shlex.split(conf.external_viewer.format(fname)), preexec_fn=os.setpgrp)
   #todo: cleanup
+
+
+def grep(pattern, subject, only=False):
+  """Print the `subject` string with text matching the `pattern` colored bright red.
+     If `only` is set to True, only text matching the `pattern` is printed.
+     An alias with the syntax 'g [-o] <pattern> <subject>' is available in the console.
+  """
+  if isinstance(pattern, basestring):
+    pattern = re.compile(pattern, re.IGNORECASE | re.LOCALE | re.DOTALL)
+  def _grep_replace(m):
+    return color_bright_red(m.group(0))
+  if only:
+    for m in pattern.finditer(str(subject)):
+      print _grep_replace(m)
+  else:
+    print pattern.sub(_grep_replace, str(subject))
 
 def play_notifier(message):
   if conf.play_notify:


### PR DESCRIPTION
This pull request adds a `grep` command for coloring and selecting text using a regular expression.
This makes it easier to look for output when printing requests in the terminal.

The `grep` function is defined as:
```python
def grep(pattern, subject, only=False):
  """Print the `subject` string with text matching the `pattern` colored bright red.
     If `only` is set to True, only text matching the `pattern` is printed.
     An alias with the syntax 'g [-o] <pattern> <subject>' is available in the console.
  """
```

For console use, `g` and `grep` are introduced as aliases to the grep command.
The aliases `g` / `grep` optionally accept `-o` as the first parameter (for setting the `only` flag).
The `pattern` argument is split on space, and is compiled into a regular expression object, no escaping needed/supported.
The `subject` is left as-is.


Example 1:
```
>>> a = create('http://lwn.net/')
>>> a()
>>> grep -o copyright[^\n]* a.response
Copyright &copy; 2015, Eklektix, Inc.<BR>
copyrighted by their creators.<br>
```

Example 2:
`>>> grep ew? "chewbacca"`
> ch**ew**bacca
